### PR TITLE
Treat OnlineStat as a "scalar" in broadcasting

### DIFF
--- a/src/OnlineStatsBase.jl
+++ b/src/OnlineStatsBase.jl
@@ -26,6 +26,8 @@ abstract type OnlineStat{T} end
 input(o::OnlineStat{T}) where {T} = T
 nobs(o::OnlineStat) = o.n
 
+Broadcast.broadcastable(o::OnlineStat) = Ref(o)
+
 # Stats that hold a collection of other stats
 abstract type StatCollection{T} <: OnlineStat{T} end
 Base.show(io::IO, o::StatCollection) = AbstractTrees.print_tree(io, o)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,14 @@ string(McclainWeight())
 @test isnan(value(fit!(Variance(), NaN)))
 end
 
+@testset "Broadcasting" begin
+    o1 = Mean()
+    o2 = Variance()
+    @test tuple.(o1, o2, [1, 2]) == [(o1, o2, 1), (o1, o2, 2)]
+    @test tuple.(o1, o2, [1, 2])[1][1] === o1
+    @test tuple.(o1, o2, [1, 2])[2][1] === o1
+end
+
 #-----------------------------------------------------------------------# Weight
 @testset "Weight" begin
 function test_weight(w::OnlineStatsBase.Weight, f::Function)


### PR DESCRIPTION
I wrote LazyGroupBy.jl that supports group reduce operation with the syntax [`reduce.(op, [xf,] grouped(key, collection))`](https://juliafolds.github.io/LazyGroupBy.jl/dev/#Base.reduce) where `op` can also be an `OnlineStat`.  However, since `OnlineStat` does not define broadcasting behavior, I need to use `reduce.(Ref(os::OnlineStat), grouped(key, collection))` ATM.  It'd be great if we can treat OnlineStat as a "scalar" in broadcasting so that I can just write `reduce.(os, grouped(key, collection))`.
