### PR TITLE
Fix docstrings for Extrema

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -221,9 +221,9 @@ Maximum and minimum (and number of occurrences for each) for a data stream of ty
     maximum(o)
     minimum(o)
 """
+mutable struct Extrema{T,S} <: OnlineStat{S}
 # T is type to store data, S is type of single observation.
 # E.g. you may want to accept any Number even if you are storing values as Float64
-mutable struct Extrema{T,S} <: OnlineStat{S}
     min::T
     max::T
     nmin::Int 


### PR DESCRIPTION
The docstring for Extrema was not showing up, because of the comment between the docstring and the definition.
This makes the docstring appear locally for me. 
This should also fix the broken link in the OnlineStats.jl docs Statistics and Models page to the Extrema Docstring.