### PR TITLE
Add fit! for two onlinestats args

### DIFF
--- a/src/OnlineStatsBase.jl
+++ b/src/OnlineStatsBase.jl
@@ -123,6 +123,7 @@ end
 ```
 """
 fit!(o::OnlineStat{T}, yi::T) where {T} = (_fit!(o, yi); return o)
+fit!(o::OnlineStat, o2::OnlineStat) = merge!(o, o2)
 
 function fit!(o::OnlineStat{I}, y::T) where {I, T}
     T == eltype(y) && error("The input for $(name(o,false,false)) is $I.  Found $T.")

--- a/src/OnlineStatsBase.jl
+++ b/src/OnlineStatsBase.jl
@@ -72,7 +72,7 @@ Base.copy(o::OnlineStat) = deepcopy(o)
 """
     merge!(stat1, stat2)
 
-Merge `stat1` into `stat2` (supported by most `OnlineStat` types).
+Merge `stat2` into `stat1` (supported by most `OnlineStat` types).
 
 # Example
 
@@ -123,6 +123,26 @@ end
 ```
 """
 fit!(o::OnlineStat{T}, yi::T) where {T} = (_fit!(o, yi); return o)
+
+"""
+    fit!(stat1::OnlineStat, stat2::OnlineStat)
+
+Alias for `merge!`. Merges `stat2` into `stat1`.
+
+Useful for reductions of OnlineStats using `fit!`.
+
+# Example
+```
+julia> v = [reduce(fit!, [1, 2, 3], init=Mean()) for _ in 1:3]
+3-element Vector{Mean{Float64, EqualWeight}}:
+ Mean: n=3 | value=2.0
+ Mean: n=3 | value=2.0
+ Mean: n=3 | value=2.0
+
+julia> reduce(fit!, v, init=Mean())
+Mean: n=9 | value=2.0
+```
+"""
 fit!(o::OnlineStat, o2::OnlineStat) = merge!(o, o2)
 
 function fit!(o::OnlineStat{I}, y::T) where {I, T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,15 @@ end
 end
 end #Weight
 
+@testset "Merging OnlineStats with fit!" begin
+    s = 100
+    x = rand(Int32, s).%100
+    ranges = Iterators.partition(1:s, 10)
 
+    v = [reduce(fit!, x[r], init=Mean()) for r in ranges]
+    r1 = reduce(fit!, v, init=Mean())
+    r2 = fit!(Mean(), x)
 
-
+    @test isapprox(value(r1), value(r2))
+    @test nobs(r1) == nobs(r2)
+end


### PR DESCRIPTION
Added this:
```julia
fit!(o::OnlineStat, o2::OnlineStat) = merge!(o, o2)
```

So that I can do this (fun is provided by user and I can't deduce that on 2nd reduce it's supposed to be merge!):
```julia
julia> fun = fit!
fit! (generic function with 4 methods)

julia> v = [reduce(fun, [1,2,3], init=Mean()) for _ in 1:3]
3-element Vector{Mean{Float64, EqualWeight}}:
 Mean: n=3 | value=2.0
 Mean: n=3 | value=2.0
 Mean: n=3 | value=2.0

julia> reduce(fun, v, init=Mean())
Mean: n=9 | value=2.0
```

Let me know if that's ok. I'll add docs and tests afterwards