### PR TITLE
Generalization of Extrema for AbstractString

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -235,7 +235,7 @@ function Extrema(T::Type = Float64)
     Extrema{T,S}(a, b, 0, 0, 0)
 end
 extrema_init(T::Type{<:Number}) = typemax(T), typemin(T), Number
-extrema_init(T::Type{String}) = "", "", String
+extrema_init(T::Type{<:AbstractString}) = T(""), T(""), AbstractString
 extrema_init(T::Type{<:TimeType}) = typemax(T), typemin(T), TimeType
 extrema_init(T::Type) = rand(T), rand(T), T
 function _fit!(o::Extrema, y)


### PR DESCRIPTION
Currently `extrema_init` includes generic methods for `<:Number` and `<:TimeType`. However, only a specific method for `String` is provided. This PR generalizes from `String` to `AbstractString`. 

This plays well for instance with CSV.jl, where by default strings are parsed as `InlineString`.