### PR TITLE
Support name for julia 1.6

### DIFF
--- a/src/OnlineStatsBase.jl
+++ b/src/OnlineStatsBase.jl
@@ -78,8 +78,16 @@ function Base.show(io::IO, o::OnlineStat)
     print(io, " value=")
     show(IOContext(io, :compact => true, :displaysize => (1, 70)), value(o))
 end
-function name(T::Type, withmodule = false, withparams = true)
-    replace(string(T), withmodule ? ""=>"" : r"([a-zA-Z]*\.)" => "", withparams ?  ""=>"" : r"\{(.*)" => "")
+
+if Base.VERSION >= v"1.7" #Support for multiple patterns requires version 1.7. 
+    function name(T::Type, withmodule = false, withparams = true)
+        replace(string(T), withmodule ? ""=>"" : r"([a-zA-Z]*\.)" => "", withparams ?  ""=>"" : r"\{(.*)" => "")
+    end
+else
+    function name(T::Type, withmodule = false, withparams = true)
+        result = replace(string(T), withmodule ? ""=>"" : r"([a-zA-Z]*\.)" => "")
+        return replace(result, withparams ?  ""=>"" : r"\{(.*)" => "")
+    end
 end
 name(o, args...) = name(typeof(o), args...)
 


### PR DESCRIPTION
the definition of `OnlineStatsBase.name` uses a `replace` with multiple pairs. that feature was added on 1.7 (revealed while testing https://github.com/JuliaFolds2/Transducers.jl/actions/runs/5363257764/jobs/9730697545)