### PR TITLE
fix possible overflows in Moments

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -505,7 +505,7 @@ end
 Moments(;weight = EqualWeight()) = Moments(zeros(4), weight, 0)
 function _fit!(o::Moments, y::Real)
     γ = o.weight(o.n += 1)
-    y2 = y * y
+    y2 = float(y) ^ 2
     @inbounds o.m[1] = smooth(o.m[1], y, γ)
     @inbounds o.m[2] = smooth(o.m[2], y2, γ)
     @inbounds o.m[3] = smooth(o.m[3], y * y2, γ)


### PR DESCRIPTION
# Problem:

If the input type of the observations have maxtype smaller than that of a float (for instance `Int`), then `y2 = y * y` can easily overflow resulting in the wrong moments.

# Example

```julia
m = fit!(Moments(), [4_000_000_000, 4_000_000_100])
Moments: n=2 | value=[4.0e9, -2.44674e18, 1.06766e18, 6.84018e18]
julia> var(m)
-3.6893488147419095e19

julia> std(m)
ERROR: DomainError with -3.6893488147419095e19:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
```

# Solution

Simply convert `y` to a `Float64` in the computation of `y2`. `Float64` is actually the type of `o.m` so the conversion was happening in any case at a later stage. By moving it to an earlier stage possible overflows are avoided.

# Caveat

Note that this does not fix possible precision errors inherent to storing the moments as `Float64`. For instance, the example above after the proposed fix returns `var(m) = 4096.0` instead of `5000`.
Also, attempting to fit float inputs with scales `sqrt(maxfloat(Float64))`  will still result in overflows.
