### PR TITLE
implement `Base.empty!` for a few `OnlineStat`s

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -149,6 +149,11 @@ function Base.delete!(o::CountMap, level)
     o.n -= x
     o
 end
+function Base.empty!(o::CountMap)
+    empty!(o.value)
+    o.n = 0
+    o
+end
 
 #-----------------------------------------------------------------------# CovMatrix
 """
@@ -287,6 +292,11 @@ value(o::Extrema) = (min=o.min, max=o.max, nmin=o.nmin, nmax=o.nmax)
 Base.extrema(o::Extrema) = (o.min, o.max)
 Base.maximum(o::Extrema) = o.max
 Base.minimum(o::Extrema) = o.min
+function Base.empty!(o::Extrema{T}) where {T}
+    o.min, o.max, _ = OnlineStatsBase.extrema_init(T)
+    o.nmin = o.nmax = o.n = 0
+    o
+end
 
 #-----------------------------------------------------------------------------# ExtremeValues
 """
@@ -481,6 +491,11 @@ function _merge!(o::Mean, o2::Mean)
 end
 Statistics.mean(o::Mean) = o.μ
 Base.copy(o::Mean) = Mean(o.μ, o.weight, o.n)
+function Base.empty!(o::Mean{T}) where {T}
+    o.μ = zero(T)
+    o.n = 0
+    o
+end
 
 #-----------------------------------------------------------------------# Moments
 """
@@ -529,6 +544,11 @@ function _merge!(o::Moments, o2::Moments)
     γ = o2.n / (o.n += o2.n)
     smooth!(o.m, o2.m, γ)
 end
+function Base.empty!(o::Moments)
+    empty!(o.m)
+    o.n = 0
+    o
+end
 
 #-----------------------------------------------------------------------# Sum
 """
@@ -549,6 +569,7 @@ Base.sum(o::Sum) = o.sum
 _fit!(o::Sum{T}, x::Number) where {T} = (o.sum += convert(T, x); o.n += 1)
 _fit!(o::Sum{T}, x::Number, n) where {T} = (o.sum += convert(T, x * n); o.n += n)
 _merge!(o::T, o2::T) where {T <: Sum} = (o.sum += o2.sum; o.n += o2.n; o)
+Base.empty!(o::Sum{T}) where {T} = (o.sum = T(0); o.n = 0; o)
 
 #-----------------------------------------------------------------------# Variance
 """
@@ -594,7 +615,12 @@ function value(o::Variance{T}) where {T}
 end
 Statistics.var(o::Variance) = value(o)
 Statistics.mean(o::Variance) = o.μ
-
+function Base.empty!(o::Variance{T}) where {T}
+    o.σ2 = zero(T) ^ 2 / one(T)
+    o.μ = zero(T) / one(T)
+    o.n = 0
+    o
+end
 
 #-----------------------------------------------------------------------# Series
 """

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -100,6 +100,12 @@ println("  > CountMap")
     @test nobs(c) == 15
     @test c[true] == 10
     @test c[false] == 5
+
+    empty!(c)
+    @test nobs(c) == 0
+    fit!(c, false, 5)
+    @test nobs(c) == 5
+    @test c[false] == 5
 end
 #-----------------------------------------------------------------------# CountMissing
 println("  > CountMissing")
@@ -170,6 +176,11 @@ println("  > Extrema")
     @test o.nmin == 7
     @test maximum(o) == 20
     @test minimum(o) == -20
+
+    empty!(o)
+    fit!(o, 10)
+    @test maximum(o) == 10
+    @test minimum(o) == 10
 end
 #-----------------------------------------------------------------------------# ExtremeValues
 println("  > ExtremeValues")
@@ -260,6 +271,9 @@ println("  > Mean")
     fit!(o, 1.0, 4)
     v = vcat(copy(y), [1.0, 1.0, 1.0, 1.0])
     @test mean(o) ≈ mean(v)
+
+    empty!(o)
+    @test nobs(o) == 0
 end
 #-----------------------------------------------------------------------# Moments
 println("  > Moments")
@@ -285,6 +299,9 @@ println("  > Moments")
     @test std(o) ≈ std(v)
     @test skewness(o) ≈ skewness(v)
     @test kurtosis(o) ≈ kurtosis(v)
+
+    empty!(o)
+    @test nobs(o) == 0
 end
 
 #-----------------------------------------------------------------------# Series
@@ -328,6 +345,9 @@ println("  > Sum")
 
     # Multiple obs method
     @test sum(fit!(Sum(Int), 10, 5)) == 50
+
+    s=empty!(Sum(Int))
+    @test nobs(s) == 0
 end
 
 #-----------------------------------------------------------------------------# TryCatch
@@ -367,6 +387,10 @@ println("  > Variance")
     @test mean(o) ≈ mean(v)
     @test var(o) ≈ var(v)
     @test std(o) ≈ std(v)
+
+    empty!(o)
+    fit!(o, 0.5, 4)
+    @test mean(o) == 0.5
 end
 
 end # end "Test Stats"


### PR DESCRIPTION
Implement `Base.empty!` for `CountMap`, `Extrema`, `Mean`, `Moments`, `Sum`, and `Variance`. Includes basic tests.

Partially addresses https://github.com/joshday/OnlineStats.jl/issues/203