### PR TITLE
stats.jl: fix merge procedure for ExtremeValues

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -337,15 +337,16 @@ function _fit!(o::ExtremeValues{T,S}, pr::Pair{<:S, Int}) where {T,S}
     length(hi) > b && delete!(hi, minimum(keys(hi)))
 end
 
-function _merge!(a::ExtremeValues, b::ExtremeValues)
-    old_n = a.n
+function _merge!(a::ExtremeValues{T}, b::ExtremeValues{T}) where {T}
+    unique_keys = Set{T}()
+    sizehint!(unique_keys, a.b + b.b)
     for pair in b.lo
+        push!(unique_keys, pair.first)
         _fit!(a, pair)
     end
     for pair in b.hi
-        _fit!(a, pair)
+       pair.first in unique_keys || _fit!(a, pair)
     end
-    a.n = old_n + b.n
 end
 
 #-----------------------------------------------------------------------# Group


### PR DESCRIPTION
Fixes a bug causing double-counting of extreme values that appear in both b.lo and b.hi.
The proposed fix is to ensure only unique keys{T} in object `b` are fitted.

Example/test:
```julia
using OnlineStatsBase
a=ExtremeValues(Int, 2)
b=ExtremeValues(Int, 2)

fit!(a, [-100, -50, -50, -33, 7, 8, 12, 38, 44, 60, 70])
# ExtremeValues: n=11 | value=(lo = OrderedDict(-100=>1, -50=>2), hi = OrderedDict(60=>1, 70=>1))

fit!(b, [-55, 65, 65])
# ExtremeValues: n=3 | value=(lo = OrderedDict(-55=>1, 65=>2), hi = OrderedDict(-55=>1, 65=>2))

merge!(a, b)
# ExtremeValues: n=14 | value=(lo = OrderedDict(-100=>1, -55=>2), hi = OrderedDict(65=>4, 70=>1))

## [should be]:
# ExtremeValues: n=14 | value=(lo = OrderedDict(-100=>1, -55=>1), hi = OrderedDict(65=>2, 70=>1))
```

I'm not a Julia programmer, so please verify!