### PR TITLE
Add mean countmap

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -149,6 +149,14 @@ function Base.delete!(o::CountMap, level)
     o.n -= x
     o
 end
+function Statistics.mean(cm::CountMap{T}) where T
+	cmdict = value(cm) 
+    k = cmdict |> keys |> collect |> sort # Sorted keys (values)
+    f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
+    weightedMean = sum(k .* f) / sum(f) # Compute the weighted mean
+    return weightedMean
+end    
+# //NOTE: Similarly we could also add quantile (that should be probably added in OnlineStats.jl)
 
 #-----------------------------------------------------------------------# CovMatrix
 """

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -150,13 +150,11 @@ function Base.delete!(o::CountMap, level)
     o
 end
 function Statistics.mean(cm::CountMap{T}) where T
-	cmdict = value(cm) 
-    k = sort(collect(keys(cmdict))) # Sorted keys (values)
-    f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
-    weightedMean = sum(k .* f) / sum(f) # Compute the weighted mean
-    return weightedMean
-end  
-
+    v = collect(keys(cm)) 
+    w = StatsBase.fweights(collect(values(cm)))
+    
+    return StatsBase.mean(v, w)
+end
 function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
     v = collect(keys(cm)) 
     w = StatsBase.fweights(collect(values(cm)))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -151,7 +151,7 @@ function Base.delete!(o::CountMap, level)
 end
 function Statistics.mean(cm::CountMap{T}) where T
 	cmdict = value(cm) 
-    k = cmdict |> keys |> collect |> sort # Sorted keys (values)
+    k = sort(collect(keys(cmdict))) # Sorted keys (values)
     f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
     weightedMean = sum(k .* f) / sum(f) # Compute the weighted mean
     return weightedMean

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -156,7 +156,16 @@ function Statistics.mean(cm::CountMap{T}) where T
     weightedMean = sum(k .* f) / sum(f) # Compute the weighted mean
     return weightedMean
 end    
-# //NOTE: Similarly we could also add quantile (that should be probably added in OnlineStats.jl)
+function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
+	cmdict = value(cm) 
+    k = sort(collect(keys(cmdict))) # Sorted keys (values)
+    f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
+    cum = cumsum(f) ./ sum(f) # Compute the cumulative frequency for each value
+    idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
+	
+    return k[idx]
+end
+Statistics.quantile(cm::CountMap{T}, qvec::Vector{<:Float64}) where T = map(x -> Statistics.quantile(cm, x), qvec)
 
 #-----------------------------------------------------------------------# CovMatrix
 """

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -155,7 +155,8 @@ function Statistics.mean(cm::CountMap{T}) where T
 end
 function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
     v, w = _compute_valueweights(cm)
-    return StatsBase.quantile(v, w, q)
+    out = T <: Integer ? round(Int, StatsBase.quantile(v, w, q)) : StatsBase.quantile(v, w, q)
+    return out
 end
 Statistics.quantile(cm::CountMap{T}, qvec::Vector{<:Float64}) where T = map(x -> Statistics.quantile(cm, x), qvec)
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -150,19 +150,21 @@ function Base.delete!(o::CountMap, level)
     o
 end
 function Statistics.mean(cm::CountMap{T}) where T
-    v = collect(keys(cm)) 
-    w = StatsBase.fweights(collect(values(cm)))
-    
+    v, w = _compute_valueweights(cm)
     return StatsBase.mean(v, w)
 end
 function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
-    v = collect(keys(cm)) 
-    w = StatsBase.fweights(collect(values(cm)))
-
+    v, w = _compute_valueweights(cm)
     return StatsBase.quantile(v, w, q)
 end
 Statistics.quantile(cm::CountMap{T}, qvec::Vector{<:Float64}) where T = map(x -> Statistics.quantile(cm, x), qvec)
 
+function _compute_valueweights(cm::CountMap{T}) where T
+    v = collect(keys(cm)) 
+    w = StatsBase.fweights(collect(values(cm)))
+    
+    return v, w
+end
 #-----------------------------------------------------------------------# CovMatrix
 """
     CovMatrix(p=0; weight=EqualWeight())

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -155,15 +155,13 @@ function Statistics.mean(cm::CountMap{T}) where T
     f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
     weightedMean = sum(k .* f) / sum(f) # Compute the weighted mean
     return weightedMean
-end    
+end  
+
 function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
-	cmdict = value(cm) 
-    k = sort(collect(keys(cmdict))) # Sorted keys (values)
-    f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
-    cum = cumsum(f) ./ sum(f) # Compute the cumulative frequency for each value
-    idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
-	
-    return k[idx]
+    v = collect(keys(cm)) 
+    w = StatsBase.fweights(collect(values(cm)))
+
+    return StatsBase.quantile(v, w, q)
 end
 Statistics.quantile(cm::CountMap{T}, qvec::Vector{<:Float64}) where T = map(x -> Statistics.quantile(cm, x), qvec)
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -153,11 +153,11 @@ function Base.delete!(o::CountMap, level)
 end
 _values_weights(o::CountMap) = collect(keys(o)), StatsBase.fweights(collect(values(o)))
 
-function Statistics.mean(o::CountMap)
+function Statistics.mean(o::CountMap{<:Number})
     v, w = _values_weights(o)
     return StatsBase.mean(v, w)
 end
-function Statistics.quantile(o::CountMap, p)
+function Statistics.quantile(o::CountMap{<:Real}, p)
     v, w = _values_weights(o)
     return StatsBase.quantile(v, w, p)
 end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -104,6 +104,8 @@ fit!(o, "A" => -1)
     OnlineStatsBase.probs(o)
     OnlineStats.pdf(o, 1)
     collect(keys(o))
+    mean(o)
+    quantile(o, .5)
     sort!(o)
     delete!(o, 1)
 """
@@ -149,23 +151,17 @@ function Base.delete!(o::CountMap, level)
     o.n -= x
     o
 end
-function Statistics.mean(cm::CountMap{T}) where T
-    v, w = _compute_valueweights(cm)
+_values_weights(o::CountMap) = collect(keys(o)), StatsBase.fweights(collect(values(o)))
+
+function Statistics.mean(o::CountMap)
+    v, w = _values_weights(o)
     return StatsBase.mean(v, w)
 end
-function Statistics.quantile(cm::CountMap{T}, q::Float64) where T
-    v, w = _compute_valueweights(cm)
-    out = T <: Integer ? round(Int, StatsBase.quantile(v, w, q)) : StatsBase.quantile(v, w, q)
-    return out
+function Statistics.quantile(o::CountMap, p)
+    v, w = _values_weights(o)
+    return StatsBase.quantile(v, w, p)
 end
-Statistics.quantile(cm::CountMap{T}, qvec::Vector{<:Float64}) where T = map(x -> Statistics.quantile(cm, x), qvec)
 
-function _compute_valueweights(cm::CountMap{T}) where T
-    v = collect(keys(cm)) 
-    w = StatsBase.fweights(collect(values(cm)))
-    
-    return v, w
-end
 #-----------------------------------------------------------------------# CovMatrix
 """
     CovMatrix(p=0; weight=EqualWeight())

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -369,4 +369,17 @@ println("  > Variance")
     @test std(o) ≈ std(v)
 end
 
+println("  > CountMap Mean")
+@testset "CountMap Mean" begin
+    # Test Mean for CountMap
+    m = Mean()
+    cm = CountMap(Int)
+    for i=1:100
+        randints = rand(1:10, 1000)
+        fit!(m, randints)
+        fit!(cm, randints)
+        @test mean(cm) ≈ mean(m) atol = 1e-6
+    end
+end
+
 end # end "Test Stats"

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -115,13 +115,13 @@ println("  > CountMap")
 
         # Quantile test
         q = rand()
+        cm_quant = quantile(cm, q)
 
         cmdict = value(cm)
         k = sort(collect(keys(cmdict))) # Sorted keys (values)
         f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
         cum = cumsum(f) ./ sum(f) # Compute the cumulative frequency for each value
         idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
-        cm_quant = quantile(cm, q)
 
         @test k[idx] ≈ cm_quant
     end

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -104,7 +104,7 @@ println("  > CountMap")
     # Test Mean and Quantile for CountMap
     m = Mean()
     cm = CountMap(Int)
-
+    q_vec = [0.1, 0.5, 1.0]
     for i=1:100
         randints = rand(1:10, 1000)
         fit!(m, randints)
@@ -113,7 +113,7 @@ println("  > CountMap")
         # Mean test
         @test mean(cm) ≈ mean(m) atol = 1e-6
 
-        # Quantile test
+        # Quantile general test 
         q = rand()
         cm_quant = quantile(cm, q)
 
@@ -124,6 +124,12 @@ println("  > CountMap")
         idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
 
         @test k[idx] ≈ cm_quant
+
+        # Quantile vector test and corner case of quantile between data points
+        cm_quant = quantile(cm, q_vec)
+        for (i,q) in enumerate(q_vec)
+            @test k[findfirst(x -> x ≥ q, cum)] ≈ cm_quant[i]
+        end
     end
 end
 

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -111,7 +111,7 @@ println("  > CountMap")
         fit!(cm, randints)
 
         # Mean test
-        # @test mean(cm) ≈ mean(m) atol = 1e-6
+        @test mean(cm) ≈ mean(m) atol = 1e-6
 
         # Quantile test
         q = rand()

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -104,22 +104,26 @@ println("  > CountMap")
     # Test Mean and Quantile for CountMap
     m = Mean()
     cm = CountMap(Int)
-    # os = OrderStats(100)
 
     for i=1:100
         randints = rand(1:10, 1000)
         fit!(m, randints)
         fit!(cm, randints)
-        # fit!(os, randints)
 
         # Mean test
-        @test mean(cm) ≈ mean(m) atol = 1e-6
+        # @test mean(cm) ≈ mean(m) atol = 1e-6
 
-        # # Quantile test
-        # q = rand()
-        # cm_quant = quantile(cm, q)
-        # os_quant = quantile(os, q)
-        # @test floor(os_quant) ≤ cm_quant ≤ ceil(os_quant)
+        # Quantile test
+        q = rand()
+
+        cmdict = value(cm)
+        k = sort(collect(keys(cmdict))) # Sorted keys (values)
+        f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
+        cum = cumsum(f) ./ sum(f) # Compute the cumulative frequency for each value
+        idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
+        cm_quant = quantile(cm, q)
+
+        @test k[idx] ≈ cm_quant
     end
 end
 

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -101,6 +101,19 @@ println("  > CountMap")
     @test c[true] == 10
     @test c[false] == 5
 end
+
+@testset "CountMap Mean" begin
+    # Test Mean for CountMap
+    m = Mean()
+    cm = CountMap(Int)
+    for i=1:100
+        randints = rand(1:10, 1000)
+        fit!(m, randints)
+        fit!(cm, randints)
+        @test mean(cm) ≈ mean(m) atol = 1e-6
+    end
+end
+
 #-----------------------------------------------------------------------# CountMissing
 println("  > CountMissing")
 @testset "CountMissing" begin
@@ -367,19 +380,6 @@ println("  > Variance")
     @test mean(o) ≈ mean(v)
     @test var(o) ≈ var(v)
     @test std(o) ≈ std(v)
-end
-
-println("  > CountMap Mean")
-@testset "CountMap Mean" begin
-    # Test Mean for CountMap
-    m = Mean()
-    cm = CountMap(Int)
-    for i=1:100
-        randints = rand(1:10, 1000)
-        fit!(m, randints)
-        fit!(cm, randints)
-        @test mean(cm) ≈ mean(m) atol = 1e-6
-    end
 end
 
 end # end "Test Stats"

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -100,17 +100,26 @@ println("  > CountMap")
     @test nobs(c) == 15
     @test c[true] == 10
     @test c[false] == 5
-end
 
-@testset "CountMap Mean" begin
-    # Test Mean for CountMap
+    # Test Mean and Quantile for CountMap
     m = Mean()
     cm = CountMap(Int)
+    # os = OrderStats(100)
+
     for i=1:100
         randints = rand(1:10, 1000)
         fit!(m, randints)
         fit!(cm, randints)
+        # fit!(os, randints)
+
+        # Mean test
         @test mean(cm) ≈ mean(m) atol = 1e-6
+
+        # # Quantile test
+        # q = rand()
+        # cm_quant = quantile(cm, q)
+        # os_quant = quantile(os, q)
+        # @test floor(os_quant) ≤ cm_quant ≤ ceil(os_quant)
     end
 end
 

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -101,38 +101,17 @@ println("  > CountMap")
     @test c[true] == 10
     @test c[false] == 5
 
-    # Test Mean and Quantile for CountMap
-    m = Mean()
-    cm = CountMap(Int)
-    q_vec = [0.1, 0.5, 1.0]
-    for i=1:100
-        randints = rand(1:10, 1000)
-        fit!(m, randints)
-        fit!(cm, randints)
+    # mean/quantile weight each key by its count, matching the same call on the raw data
+    ps = [.25, .5, .75]
+    cm = fit!(CountMap(Int), z)
+    @test mean(cm) ≈ mean(z)
+    @test quantile(cm, .5) ≈ quantile(z, .5)
+    @test quantile(cm, ps) ≈ quantile(z, ps)
 
-        # Mean test
-        @test mean(cm) ≈ mean(m) atol = 1e-6
-
-        # Quantile general test 
-        q = rand()
-        cm_quant = quantile(cm, q)
-
-        cmdict = value(cm)
-        k = sort(collect(keys(cmdict))) # Sorted keys (values)
-        f = [cmdict[x] for x in k] # Occupancies (frequency) of each values
-        cum = cumsum(f) ./ sum(f) # Compute the cumulative frequency for each value
-        idx = findfirst(x -> x ≥ q, cum) # Return the first index where the cumulative frequency is greater than or equal to `q`
-
-        @test k[idx] ≈ cm_quant
-
-        # Quantile vector test and corner case of quantile between data points
-        cm_quant = quantile(cm, q_vec)
-        for (i,q) in enumerate(q_vec)
-            @test k[findfirst(x -> x ≥ q, cum)] ≈ cm_quant[i]
-        end
-    end
+    cm = fit!(CountMap(Float64), y)
+    @test mean(cm) ≈ mean(y)
+    @test quantile(cm, ps) ≈ quantile(y, ps)
 end
-
 #-----------------------------------------------------------------------# CountMissing
 println("  > CountMissing")
 @testset "CountMissing" begin

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -111,6 +111,10 @@ println("  > CountMap")
     cm = fit!(CountMap(Float64), y)
     @test mean(cm) ≈ mean(y)
     @test quantile(cm, ps) ≈ quantile(y, ps)
+
+    cm = fit!(CountMap(String), ["a", "b"])
+    @test_throws MethodError mean(cm)
+    @test_throws MethodError quantile(cm, .5)
 end
 #-----------------------------------------------------------------------# CountMissing
 println("  > CountMissing")


### PR DESCRIPTION
Supersedes #46, which was closed; this rebuilds it on the review feedback there.

A `CountMap` stores each observed value with its count, which is exactly a set of frequency weights, so `mean` and `quantile` follow from the weighted methods already in StatsBase:

```julia
o = fit!(CountMap(Int), rand(1:10, 1000))
mean(o)
quantile(o, .5)
```

Both delegate rather than reimplementing anything, as requested in the review on #46 — with `v = collect(keys(o))` and `w = fweights(collect(values(o)))`:

- `mean(o::CountMap)` → `StatsBase.mean(v, w)`
- `quantile(o::CountMap, p)` → `StatsBase.quantile(v, w, p)`

`StatsBase.quantile` already accepts a scalar or a vector of probabilities, so one method covers both, and integer eltypes need no special-casing: a `CountMap` answers exactly as the same call on the raw observations would.

That identity is also what fixes the intermittent test failure on #46. The tests there compared against a hand-rolled step-function quantile, which disagrees with StatsBase's interpolating one whenever a probability falls between data points. They now check directly against `mean`/`quantile` on the raw data at fixed probabilities, for both an integer- and a float-valued `CountMap`.

Closes #45.